### PR TITLE
Fix/dispatch gc

### DIFF
--- a/src/SharpWebview/Webview.cs
+++ b/src/SharpWebview/Webview.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Newtonsoft.Json;
 using SharpWebview.Content;
 using System.Diagnostics;
@@ -176,6 +176,7 @@ namespace SharpWebview
             {
                 Bindings.webview_terminate(_nativeWebview);
                 Bindings.webview_destroy(_nativeWebview);
+                callbacks.Clear();
 
                 lock (dispatchFunctions)
                 {

--- a/src/SharpWebview/Webview.cs
+++ b/src/SharpWebview/Webview.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using SharpWebview.Content;
 using System.Diagnostics;
@@ -15,6 +15,7 @@ namespace SharpWebview
     {
         private bool _disposed = false;
         private List<CallBackFunction> callbacks = new List<CallBackFunction>();
+        private List<DispatchFunction> dispatchFunctions = new List<DispatchFunction>();
 
         private readonly IntPtr _nativeWebview;
 
@@ -142,7 +143,21 @@ namespace SharpWebview
         /// <param name="dispatchFunc">The function to call on the main thread</param>
         public void Dispatch(Action dispatchFunc)
         {
-            var dispatchFuncInstance = new DispatchFunction((_, __) => dispatchFunc());
+            DispatchFunction dispatchFuncInstance = null!;
+            dispatchFuncInstance = new DispatchFunction((_, __) =>
+            {
+                lock (dispatchFunctions)
+                {
+                    dispatchFunctions.Remove(dispatchFuncInstance);
+                }
+                dispatchFunc();
+            });
+
+            lock (dispatchFunctions)
+            {
+                dispatchFunctions.Add(dispatchFuncInstance); // Pin the callback for the GC
+            }
+
             Bindings.webview_dispatch(_nativeWebview, dispatchFuncInstance, IntPtr.Zero);
         }
 
@@ -161,6 +176,12 @@ namespace SharpWebview
             {
                 Bindings.webview_terminate(_nativeWebview);
                 Bindings.webview_destroy(_nativeWebview);
+
+                lock (dispatchFunctions)
+                {
+                    dispatchFunctions.Clear();
+                }
+
                 _disposed = true;
             }
         }


### PR DESCRIPTION
The `DispatchFunction` instances can get garbage-collected the same way the `CallBackFunction` instances are. The reason for this is the fact that the dispatched functions might be running later, as part of a message pump on the webview's thread handling them. This fix mirrors the indirect GC pinning that is already done for `CallBackFunction` instances, but is additionally locking the collection as it will be used to remove any functions that have been dispatched already.