### PR TITLE
Add additionalMimeTypes to HostedContent

### DIFF
--- a/src/SharpWebview/Content/HostedContent.cs
+++ b/src/SharpWebview/Content/HostedContent.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -6,6 +7,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -16,9 +18,10 @@ namespace SharpWebview.Content
     {
         private readonly IWebHost _webHost;
 
-        public HostedContent(int port = 0, bool activateLog = false)
+        public HostedContent(int port = 0, bool activateLog = false, IDictionary<string, string> additionalMimeTypes = null)
         {
             _webHost = WebHost.CreateDefaultBuilder()
+                   .ConfigureServices(s => s.AddSingleton(x => new StartupParameters() { AdditionalMimeTypes = additionalMimeTypes }))
                    .UseStartup<Startup>()
                    .UseKestrel(options => options.Listen(IPAddress.Loopback, port))
                    .ConfigureLogging((logger) => { if(!activateLog) logger.ClearProviders(); })
@@ -37,16 +40,29 @@ namespace SharpWebview.Content
 
     internal sealed class Startup
     {
+        private StartupParameters startupParameters;
+        public Startup(StartupParameters startupParameters) 
+        {
+            this.startupParameters = startupParameters;
+        }
         public void ConfigureServices(IServiceCollection services) { }
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             var workingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            app.UseFileServer(new FileServerOptions
+            var fileServerOptions = new FileServerOptions
             {
                 FileProvider = new PhysicalFileProvider(Path.Combine(workingDirectory, "app")),
                 RequestPath = "",
-                EnableDirectoryBrowsing = true
-            });
+                EnableDirectoryBrowsing = true,
+            };
+            if(startupParameters.AdditionalMimeTypes != null)
+            {
+                var extensionProvider = new FileExtensionContentTypeProvider();
+                foreach (var mimeType in startupParameters.AdditionalMimeTypes)
+                    extensionProvider.Mappings.Add(mimeType);
+                fileServerOptions.StaticFileOptions.ContentTypeProvider = extensionProvider;
+            }
+            app.UseFileServer(fileServerOptions);
         }
     }
 }

--- a/src/SharpWebview/StartupParameters.cs
+++ b/src/SharpWebview/StartupParameters.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SharpWebview
+{
+    public class StartupParameters
+    {
+        public IDictionary<string, string>? AdditionalMimeTypes { get; set; }
+    }
+}


### PR DESCRIPTION
Adds the ability to specify additional mime types for HostedContent. Enables Blazor Wasm Apps to work under WebView