### PR TITLE
Change logic of Loopback check

### DIFF
--- a/src/SharpWebview/Loopback.cs
+++ b/src/SharpWebview/Loopback.cs
@@ -18,20 +18,22 @@ namespace SharpWebview
         /// <returns>True, if the exception is present.</returns>
         public bool IsWebViewLoopbackEnabled()
         {
-            var webViewSid = GetWebViewAppContainerSid();
+            var webViewSids = GetWebViewAppContainerSids();
             return GetAllAppContainerConfigs().Any(c =>
             {
                 ConvertSidToStringSid(c.Sid, out var currentSid);
-                return currentSid == webViewSid;
+                return webViewSids.Any(webViewSid => currentSid == webViewSid);
             });
         }
 
-        private string GetWebViewAppContainerSid()
+        private IEnumerable<string> GetWebViewAppContainerSids()
         {
-            var webviewAppContainer = GetAllAppContainers()
-                .SingleOrDefault(a => a.appContainerName.ToLower() == WebViewAppContainerName);
-            ConvertSidToStringSid(webviewAppContainer.appContainerSid, out var webViewSid);
-            return webViewSid;
+            return GetAllAppContainers()
+                .Where(a => a.appContainerName.ToLower() == WebViewAppContainerName)
+                .Select(a => {
+                    ConvertSidToStringSid(a.appContainerSid, out var webViewSid);
+                    return webViewSid;
+                });
         }
 
         private List<FirewallAppContainer> GetAllAppContainers()


### PR DESCRIPTION
Change logic of Loopback check so that it checks for any exemption for an app container with a matching name, instead of requiring exactly one

for this issue: [Call to SharpWebview.Webview.Navigate fails on call to SingleOrDefault #25](https://github.com/webview/webview_csharp/issues/25)