### PR TITLE
修复 单文件发布时`-p:EnableCompressionInSingleFile=true` 不能获取工作路径

### DIFF
--- a/src/SharpWebview/Content/HostedContent.cs
+++ b/src/SharpWebview/Content/HostedContent.cs
@@ -48,10 +48,9 @@ namespace SharpWebview.Content
         public void ConfigureServices(IServiceCollection services) { }
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            var workingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var fileServerOptions = new FileServerOptions
             {
-                FileProvider = new PhysicalFileProvider(Path.Combine(workingDirectory, "app")),
+                FileProvider = new PhysicalFileProvider(Path.Combine(System.Environment.CurrentDirectory, "app")),
                 RequestPath = "",
                 EnableDirectoryBrowsing = true,
             };


### PR DESCRIPTION
```ps1
dotnet publish -c Release -p:EnableCompressionInSingleFile=true -p:PublishTrimmed=true
```
https://github.com/fldx/DesktopApp