### PR TITLE
Use System.Text.Json instead of Newtonsoft.Json

### DIFF
--- a/src/SharpWebview/SharpWebview.csproj
+++ b/src/SharpWebview/SharpWebview.csproj
@@ -35,7 +35,6 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/SharpWebview/Webview.cs
+++ b/src/SharpWebview/Webview.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Newtonsoft.Json;
 using SharpWebview.Content;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace SharpWebview
 {
@@ -206,10 +206,10 @@ namespace SharpWebview
             // This method opens the url parameter in the system browser
             Bind("openExternalLink", (id, req) =>
             {
-                dynamic args = JsonConvert.DeserializeObject(req);
+                var args = JsonSerializer.Deserialize<object[]>(req);
                 ProcessStartInfo psi = new ProcessStartInfo
                 {
-                    FileName = args[0],
+                    FileName = args[0].ToString(),
                     UseShellExecute = true
                 };
                 Process.Start (psi);


### PR DESCRIPTION
> The library is built-in as part of the shared framework for .NET Core 3.0 and later versions.

https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/overview