### PR TITLE
Add AOT Compatibility

### DIFF
--- a/examples/DesktopApp/DesktopApp.csproj
+++ b/examples/DesktopApp/DesktopApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/examples/Minimal/Minimal.csproj
+++ b/examples/Minimal/Minimal.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/SharpWebview/Loopback.cs
+++ b/src/SharpWebview/Loopback.cs
@@ -40,7 +40,7 @@ namespace SharpWebview
         {
             var size = 0u;
             var arrayValue = IntPtr.Zero;
-            var structSize = Marshal.SizeOf(typeof(FirewallAppContainer));
+            var structSize = Marshal.SizeOf<FirewallAppContainer>();
 
             var handle_pdwCntPublicACs = GCHandle.Alloc(size, GCHandleType.Pinned);
             var handle_ppACs = GCHandle.Alloc(arrayValue, GCHandleType.Pinned);
@@ -50,7 +50,7 @@ namespace SharpWebview
             var firewallApps = new List<FirewallAppContainer>();
             for (var i = 0; i < size; i++)
             {
-                var cur = (FirewallAppContainer) Marshal.PtrToStructure(arrayValue, typeof(FirewallAppContainer));
+                var cur = (FirewallAppContainer)Marshal.PtrToStructure<FirewallAppContainer>(arrayValue);
                 firewallApps.Add(cur);
                 arrayValue = new IntPtr((long)arrayValue + structSize);
             }
@@ -65,7 +65,7 @@ namespace SharpWebview
         {
             var size = 0u;
             var arrayValue = IntPtr.Zero;
-            var structSize = Marshal.SizeOf(typeof(SidAndAttributes));
+            var structSize = Marshal.SizeOf<SidAndAttributes>();
 
             var handle_pdwCntPublicACs = GCHandle.Alloc(size, GCHandleType.Pinned);
             var handle_ppACs = GCHandle.Alloc(arrayValue, GCHandleType.Pinned);
@@ -75,7 +75,7 @@ namespace SharpWebview
             var firewallAppConfigs = new List<SidAndAttributes>();
             for (var i = 0; i < size; i++)
             {
-                var currentConfig = (SidAndAttributes)Marshal.PtrToStructure(arrayValue, typeof(SidAndAttributes));
+                var currentConfig = (SidAndAttributes)Marshal.PtrToStructure<SidAndAttributes>(arrayValue);
                 firewallAppConfigs.Add(currentConfig);
                 arrayValue = new IntPtr((long)arrayValue + structSize);
             }

--- a/src/SharpWebview/SharpWebview.csproj
+++ b/src/SharpWebview/SharpWebview.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SharpWebview</AssemblyName>
     <Authors>Gerrit 'Geaz' Gazic</Authors>
@@ -35,7 +35,6 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/SharpWebview/Webview.cs
+++ b/src/SharpWebview/Webview.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 using SharpWebview.Content;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -206,10 +205,11 @@ namespace SharpWebview
             // This method opens the url parameter in the system browser
             Bind("openExternalLink", (id, req) =>
             {
-                dynamic args = JsonConvert.DeserializeObject(req);
+                string url = ExtractUrlArgument(req);
+
                 ProcessStartInfo psi = new ProcessStartInfo
                 {
-                    FileName = args[0],
+                    FileName = url,
                     UseShellExecute = true
                 };
                 Process.Start (psi);
@@ -246,6 +246,26 @@ namespace SharpWebview
                     document.attachEvent('onclick', interceptClickEvent);
                 }
             ");
+        }
+
+        private string ExtractUrlArgument(string jsonArray)
+        {
+            if (string.IsNullOrWhiteSpace(jsonArray))
+                return string.Empty;
+
+            jsonArray = jsonArray.Trim();
+
+            // Expected format: ["http..."]
+            if (!jsonArray.StartsWith("[\"http") || !jsonArray.Contains("\"]"))
+                return string.Empty;
+
+            int startIndex = 2; // After ["
+            int endIndex = jsonArray.IndexOf("\"]", startIndex);
+
+            if (endIndex == -1)
+                return string.Empty;
+
+            return jsonArray.Substring(startIndex, endIndex - startIndex);
         }
 
         private bool? CheckLoopbackException(string url)


### PR DESCRIPTION
This removes the need for any JSON library which makes the project compatible with AOT. I also removed .NET 6 because AOT is .NET 7 and later.

The Marshal method updates also remove the need for reflection for AOT compatibility.

This does not force AOT, simply makes it an option. To publish a package that works with AOT you'll need to adjust the dotnet pack command. This keeps the AOT version separate for those who want it.

```
dotnet pack -p:PublishAot=true -p:PackageId=SharpWebview.Aot
```

This should be fully working. I was able to build the `DesktopApp` example as AOT and it was fully functional. The size was 11.6MB and executable showed the correct dependencies.