### PR TITLE
Fix CheckLoopbackException url-based condition

### DIFF
--- a/src/SharpWebview/Webview.cs
+++ b/src/SharpWebview/Webview.cs
@@ -273,7 +273,7 @@ namespace SharpWebview
             // https://docs.microsoft.com/de-de/windows/win32/sysinfo/operating-system-version
             if(Environment.OSVersion.Version.Major < 6 || (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor < 2))
                 return true;
-            else if(url.Contains("localhost") && !url.Contains("127.0.0.1"))
+            else if(!url.Contains("localhost") && !url.Contains("127.0.0.1"))
                 return null;
 
             var loopBack = new Loopback();


### PR DESCRIPTION
Fixes #51 by making sure the loopback exception check only runs for loopback (i.e. localhost and 127.0.0.1) URLs, rather than for almost all URLs which is the behaviour now.